### PR TITLE
Fix stash

### DIFF
--- a/lib/temperature_monitor/stash.ex
+++ b/lib/temperature_monitor/stash.ex
@@ -1,23 +1,23 @@
 defmodule TemperatureMonitor.Stash do
   use GenServer
 
-  def start_link(filelist) do
-    {:ok, _pid} = GenServer.start_link(__MODULE__, filelist)
+  def start_link do
+    GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
   end
 
-  def save_value(pid, value) do
-    GenServer.cast pid, {:save_value, value}
+  def save_value(pid \\ __MODULE__, serial_number, value) do
+    GenServer.cast pid, {:save_value, serial_number, value}
   end
 
-  def get_value(pid) do
+  def get_value(pid \\ __MODULE__) do
     GenServer.call pid, :get_value
   end
 
-  def handle_call(:get_value, _from, filelist) do
-    {:reply, filelist, filelist}
+  def handle_call(:get_value, _from, values) do
+    {:reply, values, values}
   end
 
-  def handle_cast({:save_value, value}, _filelist) do
-    {:noreply, value}
+  def handle_cast({:save_value, serial_number, value}, values) do
+    {:noreply, Map.put(values, serial_number, value)}
   end
 end

--- a/lib/temperature_monitor/supervisor.ex
+++ b/lib/temperature_monitor/supervisor.ex
@@ -8,7 +8,7 @@ defmodule TemperatureMonitor.Supervisor do
   end
 
   def start_workers(sup, filelist) do
-    {:ok, stash} = Supervisor.start_child(sup, worker(TemperatureMonitor.Stash, [filelist])) |> IO.inspect
+    {:ok, stash} = Supervisor.start_child(sup, worker(TemperatureMonitor.Stash, [])) |> IO.inspect
     Supervisor.start_child(sup, supervisor(TemperatureMonitor.SubSupervisor, [stash])) |> IO.inspect
   end
 

--- a/test/stash_test.exs
+++ b/test/stash_test.exs
@@ -1,0 +1,10 @@
+defmodule StashTest do
+  use ExUnit.Case
+  alias TemperatureMonitor.Stash
+
+  test "it can store and retrieve values" do
+    assert Stash.get_value() == %{}
+    Stash.save_value("abc123", 26.125)
+    assert Stash.get_value() == %{"abc123" => 26.125}
+  end
+end


### PR DESCRIPTION
I noticed that the `TemperatureMonitor.Stash` could be cleaned up a little so that it was actually storing and returning values. I added a test to verify its behavior.

I also thought that we probably didn't need to initialize its mapping of serial numbers to temperatures since we will be getting temperature updates very regularly and this map will get populated pretty quickly.

/cc @newellista 
